### PR TITLE
Update code fix title and package version to 1.0.1

### DIFF
--- a/Optilizer/Optilizer.CodeFixes/NullCoalesceQueryAlwaysContainsCodeFixProvider.cs
+++ b/Optilizer/Optilizer.CodeFixes/NullCoalesceQueryAlwaysContainsCodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace Optilizer
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: "Refactor to always call Contains with fallback",
+                    title: "Refactor by keeping conditions",
                     createChangedDocument: c => ApplyFixAsync(context.Document, invocation, c),
                     equivalenceKey: "RefactorNullCoalescingAlwaysContains"),
                 diagnostic);

--- a/Optilizer/Optilizer.Package/Optilizer.Package.csproj
+++ b/Optilizer/Optilizer.Package/Optilizer.Package.csproj
@@ -9,21 +9,23 @@
 
   <PropertyGroup>
     <PackageId>Optilizer</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <Authors>petrovicz</Authors>
     <PackageProjectUrl>https://github.com/petrovicz/Optilizer</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
     <RepositoryUrl>https://github.com/petrovicz/Optilizer</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Roslyn analyzer to optimize your code</Description>
-    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
-    <PackageTags>Roslyn, Analyzer, Refactoring, Productivity, CodeAnalysis, C#, CSharp, Optilizer, analyzers, optimize, LINQ</PackageTags>
+    <PackageReleaseNotes>Setting a better title to the code fix that keeps conditions</PackageReleaseNotes>
+    <PackageTags>Roslyn, Analyzer, Refactoring, Productivity, CodeAnalysis, C#, CSharp, Optilizer, analyzers, optimize, LINQ, EF, entity, framework</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
 
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
+
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,9 +35,9 @@
 
   <ItemGroup>
     <None Update="tools\*.ps1" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="\"/>
-    <None Include="logo.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+    <None Include="logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <Target Name="_AddAnalyzersToOutput">

--- a/Optilizer/Optilizer.Vsix/source.extension.vsixmanifest
+++ b/Optilizer/Optilizer.Vsix/source.extension.vsixmanifest
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Optilizer.5c9126b8-b8c2-491d-9502-0872dfc1da00" Version="1.0.0" Language="en-US" Publisher="petrovicz" />
+        <Identity Id="Optilizer.5c9126b8-b8c2-491d-9502-0872dfc1da00" Version="1.0.1" Language="en-US" Publisher="petrovicz" />
         <DisplayName>Optilizer</DisplayName>
         <Description xml:space="preserve">Roslyn analyzer to optimize your code</Description>
         <Icon>logo.png</Icon>
-        <Tags>Roslyn, Analyzer, Refactoring, Productivity, CodeAnalysis, C#, CSharp, Optilizer, analyzers, optimize, LINQ</Tags>
+        <Tags>Roslyn, Analyzer, Refactoring, Productivity, CodeAnalysis, C#, CSharp, Optilizer, analyzers, optimize, LINQ, EF. entity, framework</Tags>
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">

--- a/Optilizer/Optilizer/NullCoalesceQueryExpressionAnalyzer.cs
+++ b/Optilizer/Optilizer/NullCoalesceQueryExpressionAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Optilizer
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId,
             "Avoid ?? inside Contains in LINQ query where clause",
-			"Using ?? here causes Entity Framework to generate a COALESCE SQL command, which prevents optimal index usage and can severely impact query performance.",
+			"Using ?? here causes EF to generate a COALESCE SQL command, which prevents optimal index usage and can severely impact query performance.",
             "Usage",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);

--- a/Optilizer/Optilizer/NullCoalesceQueryMethodAnalyzer.cs
+++ b/Optilizer/Optilizer/NullCoalesceQueryMethodAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Optilizer
 		private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
 			DiagnosticId,
 			"Avoid ?? inside Contains within IQueryable.Where",
-			"Using ?? here causes Entity Framework to generate a COALESCE SQL command, which prevents optimal index usage and can severely impact query performance.",
+			"Using ?? here causes EF to generate a COALESCE SQL command, which prevents optimal index usage and can severely impact query performance.",
 			"Usage",
 			DiagnosticSeverity.Warning,
 			isEnabledByDefault: true);


### PR DESCRIPTION
- Changed code fix title for clarity in NullCoalesceQueryAlwaysContainsCodeFixProvider.cs.
- Updated package version from 1.0.0 to 1.0.1 in Optilizer.Package.csproj with improved release notes.
- Expanded package tags to include "EF", "entity", and "framework" for better discoverability.
- Modified diagnostic message descriptions in NullCoalesceQueryExpressionAnalyzer.cs and NullCoalesceQueryMethodAnalyzer.cs for consistency.
- Updated XML structure in source.extension.vsixmanifest to reflect new version and tags.